### PR TITLE
add support for additional es6 import syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,10 @@ var path = require("path");
 
 module.exports = function(source) {
   this.cacheable();
-  var regex = /import +(\w+) +from +([\'\"])(.*?)\2/gm;
+  var regex = /import+ ?(\w+ from)? +([\'\"])(.*?)\2/gm
+  var importModules = /import +(\w+) +from +([\'\"])(.*?)\2/gm;
+  var importFiles = /import +([\'\"])(.*?)\1/gm;
+  var module =true;
   var resourceDir = path.dirname(this.resourcePath);
   function replacer(match, obj, quote, filename) {
     var modules = [];
@@ -11,13 +14,19 @@ module.exports = function(source) {
     var result = glob.sync(filename, {
       cwd: resourceDir
     })
-    .map(function(file, index) {
-      var moduleName = obj + index;
-      modules.push(moduleName);
-      return 'import * as ' + moduleName + ' from ' + quote + file + quote;
+    result=result.map(function(file, index) {
+      var fileName = quote + file + quote;
+      if (match.match(importModules)){
+        var moduleName = obj + index;
+        modules.push(moduleName);
+        return 'import * as ' + moduleName + ' from ' + fileName;
+      }else if(match.match(importFiles)){
+        module = false;
+        return 'import '+ fileName
+      }
     })
     .join(';\n');
-    if (result) {
+    if (result && module) {
       result += '\nlet ' + obj + ' = [' + modules.join(', ') + ']';
     }
     return result;


### PR DESCRIPTION
I added support for the syntax 'import [filename]' syntax.  The process will import the files for their side effects, as per the ex6 syntax. please let me know if there is different format you would prefer for this change
