### PR TITLE
feat: keep all imports in single line for correct debugger line numbering

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ module.exports = function(source) {
           return 'import ' + fileName;
         }
       })
-      .join(';\n');
+      .join('; ');
     if (result && withModules) {
-      result += '\nlet ' + obj + ' = [' + modules.join(', ') + ']';
+      result += '; let ' + obj + ' = [' + modules.join(', ') + ']';
     }
     return result;
   }


### PR DESCRIPTION
If imports are expanded into multiple lines then browser console output doesn't show correct line number. The easiest fix for this issue is to keep all generated code in one line.
