### PR TITLE
Tweaked regex to allow 1 or most spaces before

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require("path");
 
 module.exports = function(source) {
   this.cacheable();
-  var regex = /.?import + ?((\w+) from )?([\'\"])(.*?)\3/gm;
+  var regex = /.?import + ?((\w+) +from )?([\'\"])(.*?)\3/gm;
   var importModules = /import +(\w+) +from +([\'\"])(.*?)\2/gm;
   var importFiles = /import +([\'\"])(.*?)\1/gm;
   var importSass = /@import +([\'\"])(.*?)\1/gm;


### PR DESCRIPTION
Was having issues using the glob pattern with extra spaces without adding the `+`, e.g...

The following would only work if written like the second line...
```js
import actions          from '../../store/**/actions.js'; // Bad
import actions from '../../store/**/actions.js';          // Good
```