### PR TITLE
Call loader.addDependency so that new files can trigger a rebuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var path = require("path");
 
 module.exports = function(source) {
   this.cacheable();
+  var self = this;
   var regex = /.?import + ?((\w+) +from )?([\'\"])(.*?)\3/gm;
   var importModules = /import +(\w+) +from +([\'\"])(.*?)\2/gm;
   var importFiles = /import +([\'\"])(.*?)\1/gm;
@@ -18,6 +19,7 @@ module.exports = function(source) {
       })
       .map(function(file, index) {
         var fileName = quote + file + quote;
+        self.addDependency(fileName);
         if (match.match(importSass)) {
           return '@import ' + fileName;
         } else if (match.match(importModules)) {


### PR DESCRIPTION
We use this plugin only to import sass/scss files but one drawback with all glob loaders is that new files doesn't properly trigger a rebuild when using the dev-server/watch mode.

For instance if we create a new files `test.scss` the content is not used unless we restart webpack.

Since I saw that there is an [addDependency](https://webpack.js.org/api/loaders/#this-adddependency) method on the loaders I tried it and it solved the issue : )

Note that this may need further testing, especially for glob loading js files. Also there is no `removeDependency` but only a `clearDependencies` which remove all dependencies so I didn't implement such thing. On my tests I created and removed multiple scss files and it didn't cause any issue. 