### PR TITLE
Add module object with reference to imported filename

### DIFF
--- a/example/test.js
+++ b/example/test.js
@@ -5,3 +5,6 @@ import './foo/**/*.scss';
 
 console.log(allModules);
 console.log(testModules);
+
+console.log(allModulesByPath);
+console.log(testModulesByPath);

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = function(source) {
   var resourceDir = path.dirname(this.resourcePath);
   function replacer(match, fromStatement, obj, quote, filename) {
     var modules = [];
+    var modulesDict = {};
     var withModules = false;
     if (!glob.hasMagic(filename)) return match;
     var result = glob
@@ -22,6 +23,7 @@ module.exports = function(source) {
           return '@import ' + fileName;
         } else if (match.match(importModules)) {
           var moduleName = obj + index;
+          modulesDict[fileName] = moduleName;
           modules.push(moduleName);
           withModules = true;
           return 'import * as ' + moduleName + ' from ' + fileName;
@@ -31,6 +33,10 @@ module.exports = function(source) {
       })
       .join('; ');
     if (result && withModules) {
+      var modulesDictEntries = Object.entries(modulesDict)
+          .map(function(entry) { return entry[0] + ":" + entry[1]; })
+          .join(",");
+      result += "; let " + obj + "ByPath = {" + modulesDictEntries + '}';
       result += '; let ' + obj + ' = [' + modules.join(', ') + ']';
     }
     return result;


### PR DESCRIPTION
In order to keep track of the file name that the module imports from, I have added a `xxxByPath` variable that contains a map from the filename to the corresponding module.

This is "non-breaking" in that this variable is unlikely to be used by anyone.

A better solution (which is quite breaking and not implemented here) would be to only output the new variable, since it can be used to generate the current array via `Object.values(moduleObject)`.  That way only the variable name the user specified would be used.